### PR TITLE
Build standalone ioq3ded, fix asset timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.12 as quake-n-bake
 
 RUN apk add --no-cache git gcc make libc-dev
 RUN git clone https://github.com/ioquake/ioq3
-RUN cd /ioq3 && make BUILD_MISSIONPACK=0 BUILD_BASEGAME=0 BUILD_CLIENT=0 BUILD_SERVER=1 BUILD_GAME_SO=0 BUILD_GAME_QVM=0 BUILD_RENDERER_OPENGL2=0
+RUN cd /ioq3 && make BUILD_MISSIONPACK=0 BUILD_BASEGAME=0 BUILD_CLIENT=0 BUILD_SERVER=1 BUILD_GAME_SO=0 BUILD_GAME_QVM=0 BUILD_RENDERER_OPENGL2=0 BUILD_STANDALONE=1
 RUN cp /ioq3/build/release-linux-$(uname -m)/ioq3ded.$(uname -m) /usr/local/bin/ioq3ded
 
 FROM alpine:3.12

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ q3: gen
 gen: ## Generate and embed templates
 	@go run tools/genstatic.go public public
 
-VERSION ?= v1.0.4
+VERSION ?= v1.0.5
 IMAGE   ?= docker.io/criticalstack/quake:$(VERSION)
 
 .PHONY: build

--- a/cmd/q3/app/server/server.go
+++ b/cmd/q3/app/server/server.go
@@ -12,7 +12,6 @@ import (
 	quakeclient "github.com/criticalstack/quake-kube/internal/quake/client"
 	"github.com/criticalstack/quake-kube/internal/quake/content"
 	quakeserver "github.com/criticalstack/quake-kube/internal/quake/server"
-	netutil "github.com/criticalstack/quake-kube/internal/util/net"
 	httputil "github.com/criticalstack/quake-kube/internal/util/net/http"
 	"github.com/criticalstack/quake-kube/public"
 )
@@ -33,14 +32,6 @@ func NewCommand() *cobra.Command {
 		Short:        "q3 server",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if opts.ClientAddr == "" {
-				hostIPv4, err := netutil.DetectHostIPv4()
-				if err != nil {
-					return err
-				}
-				opts.ClientAddr = fmt.Sprintf("%s:8080", hostIPv4)
-			}
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -94,7 +85,7 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ContentServer, "content-server", "http://content.quakejs.com", "content server url")
 	cmd.Flags().BoolVar(&opts.AcceptEula, "agree-eula", false, "agree to the Quake 3 demo EULA")
 	cmd.Flags().StringVar(&opts.AssetsDir, "assets-dir", "assets", "location for game files")
-	cmd.Flags().StringVar(&opts.ClientAddr, "client-addr", "", "client address <host>:<port>")
+	cmd.Flags().StringVar(&opts.ClientAddr, "client-addr", "0.0.0.0:8080", "client address <host>:<port>")
 	cmd.Flags().StringVar(&opts.ServerAddr, "server-addr", "0.0.0.0:27960", "dedicated server <host>:<port>")
 	cmd.Flags().DurationVar(&opts.WatchInterval, "watch-interval", 15*time.Second, "dedicated server <host>:<port>")
 	return cmd

--- a/example.yaml
+++ b/example.yaml
@@ -22,7 +22,7 @@ spec:
         - --config=/config/config.yaml
         - --content-server=http://localhost:9090
         - --agree-eula
-        image: docker.io/criticalstack/quake:v1.0.4
+        image: docker.io/criticalstack/quake:v1.0.5
         name: server
         ports:
         - containerPort: 8080
@@ -40,7 +40,7 @@ spec:
         - q3
         - content
         - --seed-content-url=http://content.quakejs.com
-        image: docker.io/criticalstack/quake:v1.0.4
+        image: docker.io/criticalstack/quake:v1.0.5
         name: content-server
         ports:
         - containerPort: 9090

--- a/internal/quake/client/server.go
+++ b/internal/quake/client/server.go
@@ -23,8 +23,8 @@ func (s *Server) Serve(l net.Listener) error {
 		s := &http.Server{
 			Addr:           s.Addr,
 			Handler:        s.Handler,
-			ReadTimeout:    10 * time.Second,
-			WriteTimeout:   10 * time.Second,
+			ReadTimeout:    5 * time.Minute,
+			WriteTimeout:   5 * time.Minute,
 			MaxHeaderBytes: 1 << 20,
 		}
 		if err := s.Serve(httpL); err != cmux.ErrListenerClosed {

--- a/internal/quake/server/server.go
+++ b/internal/quake/server/server.go
@@ -58,6 +58,9 @@ func (s *Server) Start(ctx context.Context) error {
 		"+set", "dedicated", "1",
 		"+set", "net_ip", host,
 		"+set", "net_port", port,
+		"+set", "com_homepath", s.Dir,
+		"+set", "com_basegame", "baseq3",
+		"+set", "com_gamename", "Quake3Arena",
 		"+exec", "server.cfg",
 	}
 	cmd := exec.CommandContext(ctx, "ioq3ded", args...)

--- a/internal/util/net/http/http.go
+++ b/internal/util/net/http/http.go
@@ -10,7 +10,7 @@ import (
 
 func GetBody(url string) ([]byte, error) {
 	client := http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 5 * time.Minute,
 	}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,7 @@
             if (!host.includes(":")) { host = host + ":80" }
             var args = ['+set', 'fs_cdn', host, '+connect', host];
             args.push.apply(args, ['+set', 'cl_allowDownload', '1'])
+            args.push.apply(args, ['+set', 'cl_timeout', '15'])
             args.push.apply(args, ['+name', localStorage.playerName])
             args.push.apply(args, getQueryCommands());
             var inputPassword = document.getElementById("password");


### PR DESCRIPTION
When specifying `BUILD_STANDALONE=1` for ioq3ded, the default `com_homepath`, `com_basegame`, and `com_gamename` change to foo/foobar, so this sets those explicitly to their previously default values. This can be exposed via option later to allow for custom games. This also fixes the short read timeout used by CopyAssets.

This should fix the output brought up in #15.